### PR TITLE
fix for android  monochrome_public_apk build

### DIFF
--- a/config.gni
+++ b/config.gni
@@ -20,34 +20,34 @@ challenge_bypass_target = ""
 
 # See https://forge.rust-lang.org/platform-support.html for possible targets
 if (is_win) {
-  if (target_cpu == "x86") {
+  if (current_cpu == "x86") {
     challenge_bypass_rust_flags += " -C target-feature=+crt-static"
     challenge_bypass_target = "i686-pc-windows-msvc"
-  } else if (target_cpu == "x64") {
+  } else if (current_cpu == "x64") {
     challenge_bypass_target = "x86_64-pc-windows-msvc"
   }
 } else if (is_mac) {
-  if (target_cpu == "x64") {
+  if (current_cpu == "x64") {
     challenge_bypass_target = "x86_64-apple-darwin"
   }
 } else if (is_linux) {
-  if (target_cpu == "x64") {
+  if (current_cpu == "x64") {
     challenge_bypass_target = "x86_64-unknown-linux-gnu"
   }
 } else if (is_android) {
-  if (target_cpu == "arm") {
+  if (current_cpu == "arm") {
     challenge_bypass_target = "arm-linux-androideabi"
-  } else if (target_cpu == "arm64") {
+  } else if (current_cpu == "arm64") {
     challenge_bypass_target = "aarch64-linux-android"
-  } else if (target_cpu == "x86") {
+  } else if (current_cpu == "x86") {
     challenge_bypass_target = "i686-linux-android"
-  } else if (target_cpu == "x64") {
+  } else if (current_cpu == "x64") {
     challenge_bypass_target = "x86_64-linux-android"
   }
 } else if (is_ios) {
-  if (target_cpu == "arm64") {
+  if (current_cpu == "arm64") {
     challenge_bypass_target = "aarch64-apple-ios"
-  } else if (target_cpu == "x64") {
+  } else if (current_cpu == "x64") {
     challenge_bypass_target = "x86_64-apple-ios"
   }
 }


### PR DESCRIPTION
When building `monochrome_public_apk` for Android 64 bit `target_cpu`, it builds both 32 and 64 bit binaries.  Ninja generates targets for both platforms and `current_cpu` reflects the correct one.