### PR TITLE
fix message truncation issue for strings with embedded nulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       script:
         - cargo fmt -- --check
         - cargo clippy
-    - name: "Linux Build and C++ Example"
+    - name: "Linux Build, Test and C++ Example"
       os: linux
       rust: nightly
       before_script:
@@ -27,6 +27,7 @@ matrix:
         - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y valgrind
       script:
         - cargo build
+        - cargo test
         - make examples/cpp.out
         - valgrind --leak-check=yes --error-exitcode=1 ./examples/cpp.out
     - name: "Linux Build and C++ Example - NO_CXXEXCEPTIONS"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "challenge-bypass-ristretto-ffi"
-version = "1.0.0-pre.1"
+version = "1.0.0-pre.2"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "challenge-bypass-ristretto 1.0.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["eV <ev@7pr.xyz>"]
 name = "challenge-bypass-ristretto-ffi"
-version = "1.0.0-pre.1"
+version = "1.0.0-pre.2"
 
 [dependencies]
 base64 = "0.9.3"

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -111,7 +111,7 @@ int main() {
   VerificationKey client_vKey = restored_unblinded_tok.derive_verification_key();
   check_exception();
   // client signs a message using the shared key
-  std::string message = "test message";
+  std::string message = std::string("\0test message", 13);
   VerificationSignature client_sig = client_vKey.sign(message);
   check_exception();
   // client sends the token preimage, signature and message to the server
@@ -139,7 +139,7 @@ int main() {
   }
   check_exception();
 
-  if (server_vKey.verify(server_sig, "foobar")) {
+  if (server_vKey.verify(server_sig, std::string("\0foobar", 7))) {
     check_exception();
     cerr<<"ERROR: wrong sigs equal\n";
     return 1;

--- a/examples/golang/Dockerfile
+++ b/examples/golang/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y valgrind
 COPY --from=rust_builder /src/target/x86_64-unknown-linux-musl/debug/libchallenge_bypass_ristretto.a /usr/lib/
 COPY . /src
 WORKDIR /src
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 RUN make go-lint
 RUN go build --ldflags '-extldflags "-static"' -o examples/golang.out examples/golang/main.go
 RUN go build -o examples/golang.dyn.out examples/golang/main.go

--- a/examples/golang/Dockerfile
+++ b/examples/golang/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y valgrind
 COPY --from=rust_builder /src/target/x86_64-unknown-linux-musl/debug/libchallenge_bypass_ristretto.a /usr/lib/
 COPY . /src
 WORKDIR /src
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+RUN GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 RUN make go-lint
 RUN go build --ldflags '-extldflags "-static"' -o examples/golang.out examples/golang/main.go
 RUN go build -o examples/golang.dyn.out examples/golang/main.go

--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -80,7 +80,7 @@ func main() {
 	clientvKey := clientUnblindedToken.DeriveVerificationKey()
 
 	// client signs a message using the shared key
-	clientSig, err := clientvKey.Sign("test message")
+	clientSig, err := clientvKey.Sign("\x00test message")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -94,7 +94,7 @@ func main() {
 	servervKey := serverUnblindedToken.DeriveVerificationKey()
 
 	// server signs the same message using the shared key and compares the client signature to it's own
-	result, err := servervKey.Verify(clientSig, "test message")
+	result, err := servervKey.Verify(clientSig, "\x00test message")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -103,7 +103,7 @@ func main() {
 	}
 
 	// server signs the wrong message using the shared key and compares the client signature to it's own
-	result, err = servervKey.Verify(clientSig, "message")
+	result, err = servervKey.Verify(clientSig, "\x00message")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/lib.go
+++ b/lib.go
@@ -66,13 +66,12 @@ func (t *TokenPreimage) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the token preimage from text.
-func (t *TokenPreimage) UnmarshalText(text []byte) error {
+func (t *TokenPreimage) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.token_preimage_decode_base64(cs)
+	raw := C.token_preimage_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode token preimage")
 	}
@@ -134,13 +133,12 @@ func (t *Token) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the token from text.
-func (t *Token) UnmarshalText(text []byte) error {
+func (t *Token) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.token_decode_base64(cs)
+	raw := C.token_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode token")
 	}
@@ -174,13 +172,12 @@ func (t *BlindedToken) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the blinded token from text.
-func (t *BlindedToken) UnmarshalText(text []byte) error {
+func (t *BlindedToken) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.blinded_token_decode_base64(cs)
+	raw := C.blinded_token_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decoded blinded token")
 	}
@@ -214,13 +211,12 @@ func (t *SignedToken) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the signed token from text.
-func (t *SignedToken) UnmarshalText(text []byte) error {
+func (t *SignedToken) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.signed_token_decode_base64(cs)
+	raw := C.signed_token_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode signed token")
 	}
@@ -298,13 +294,12 @@ func (k *SigningKey) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the signing key from text.
-func (k *SigningKey) UnmarshalText(text []byte) error {
+func (k *SigningKey) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.signing_key_decode_base64(cs)
+	raw := C.signing_key_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode signing key")
 	}
@@ -380,13 +375,12 @@ func (t *UnblindedToken) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the unblinded token from text.
-func (t *UnblindedToken) UnmarshalText(text []byte) error {
+func (t *UnblindedToken) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.unblinded_token_decode_base64(cs)
+	raw := C.unblinded_token_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode unblinded token")
 	}
@@ -459,13 +453,12 @@ func (t *VerificationSignature) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the unblinded token from text.
-func (t *VerificationSignature) UnmarshalText(text []byte) error {
+func (t *VerificationSignature) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.verification_signature_decode_base64(cs)
+	raw := C.verification_signature_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode verification signature")
 	}
@@ -499,13 +492,12 @@ func (t *PublicKey) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the unblinded token from text.
-func (t *PublicKey) UnmarshalText(text []byte) error {
+func (t *PublicKey) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.public_key_decode_base64(cs)
+	raw := C.public_key_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode public key")
 	}
@@ -565,13 +557,12 @@ func (proof *DLEQProof) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the unblinded token from text.
-func (proof *DLEQProof) UnmarshalText(text []byte) error {
+func (proof *DLEQProof) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.dleq_proof_decode_base64(cs)
+	raw := C.dleq_proof_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode DLEQ proof")
 	}
@@ -710,13 +701,12 @@ func (proof *BatchDLEQProof) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText unmarshalls the unblinded token from text.
-func (proof *BatchDLEQProof) UnmarshalText(text []byte) error {
+func (proof *BatchDLEQProof) UnmarshalText(bytes []byte) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(string(text))
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.batch_dleq_proof_decode_base64(cs)
+	raw := C.batch_dleq_proof_decode_base64((*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
+
 	if raw == nil {
 		return wrapLastError("Failed to decode batch DLEQ proof")
 	}

--- a/lib.go
+++ b/lib.go
@@ -411,9 +411,8 @@ func (k *VerificationKey) Sign(message string) (*VerificationSignature, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(message)
-	defer C.free(unsafe.Pointer(cs))
-	raw := C.verification_key_sign_sha512(k.raw, cs)
+	bytes := []byte(message)
+	raw := C.verification_key_sign_sha512(k.raw, (*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
 	if raw == nil {
 		return nil, wrapLastError("Failed to sign message")
 	}
@@ -427,9 +426,8 @@ func (k *VerificationKey) Verify(sig *VerificationSignature, message string) (bo
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cs := C.CString(message)
-	defer C.free(unsafe.Pointer(cs))
-	result := C.verification_key_invalid_sha512(k.raw, sig.raw, cs)
+	bytes := []byte(message)
+	result := C.verification_key_invalid_sha512(k.raw, sig.raw, (*C.uint8_t)(&bytes[0]), C.size_t(len(bytes)))
 	if result < 0 {
 		return false, wrapLastError("Failed to verify message signature")
 	}

--- a/src/lib.h
+++ b/src/lib.h
@@ -388,7 +388,8 @@ void verification_key_destroy(C_VerificationKey *key);
  */
 int verification_key_invalid_sha512(const C_VerificationKey *key,
                                     const C_VerificationSignature *sig,
-                                    const char *message);
+                                    const uint8_t *message,
+                                    uintptr_t message_length);
 
 /**
  * Take a reference to a `VerificationKey` and use it to sign a message
@@ -397,7 +398,8 @@ int verification_key_invalid_sha512(const C_VerificationKey *key,
  * destroy the `VerificationSignature` once you are done with it!
  */
 C_VerificationSignature *verification_key_sign_sha512(const C_VerificationKey *key,
-                                                      const char *message);
+                                                      const uint8_t *message,
+                                                      uintptr_t message_length);
 
 /**
  * Decode from base64 C string.

--- a/src/lib.h
+++ b/src/lib.h
@@ -99,7 +99,7 @@ typedef struct C_VerificationSignature C_VerificationSignature;
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_BatchDLEQProof *batch_dleq_proof_decode_base64(const char *s);
+C_BatchDLEQProof *batch_dleq_proof_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `BatchDLEQProof` once you are done with it.
@@ -152,7 +152,7 @@ C_BatchDLEQProof *batch_dleq_proof_new(const C_BlindedToken *const *blinded_toke
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_BlindedToken *blinded_token_decode_base64(const char *s);
+C_BlindedToken *blinded_token_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `BlindedToken` once you are done with it.
@@ -174,7 +174,7 @@ void c_char_destroy(char *s);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_DLEQProof *dleq_proof_decode_base64(const char *s);
+C_DLEQProof *dleq_proof_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `DLEQProof` once you are done with it.
@@ -216,7 +216,7 @@ char *last_error_message(void);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_PublicKey *public_key_decode_base64(const char *s);
+C_PublicKey *public_key_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `PublicKey` once you are done with it.
@@ -233,7 +233,7 @@ char *public_key_encode_base64(const C_PublicKey *t);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_SignedToken *signed_token_decode_base64(const char *s);
+C_SignedToken *signed_token_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `SignedToken` once you are done with it.
@@ -250,7 +250,7 @@ char *signed_token_encode_base64(const C_SignedToken *t);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_SigningKey *signing_key_decode_base64(const char *s);
+C_SigningKey *signing_key_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `SigningKey` once you are done with it.
@@ -305,7 +305,7 @@ C_BlindedToken *token_blind(const C_Token *token);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_Token *token_decode_base64(const char *s);
+C_Token *token_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `Token` once you are done with it.
@@ -322,7 +322,7 @@ char *token_encode_base64(const C_Token *t);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_TokenPreimage *token_preimage_decode_base64(const char *s);
+C_TokenPreimage *token_preimage_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `TokenPreimage` once you are done with it.
@@ -347,7 +347,7 @@ C_Token *token_random(void);
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_UnblindedToken *unblinded_token_decode_base64(const char *s);
+C_UnblindedToken *unblinded_token_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Take a reference to an `UnblindedToken` and use it to derive a `VerificationKey`
@@ -406,7 +406,7 @@ C_VerificationSignature *verification_key_sign_sha512(const C_VerificationKey *k
  * If something goes wrong, this will return a null pointer. Don't forget to
  * destroy the returned pointer once you are done with it!
  */
-C_VerificationSignature *verification_signature_decode_base64(const char *s);
+C_VerificationSignature *verification_signature_decode_base64(const uint8_t *s, uintptr_t s_length);
 
 /**
  * Destroy a `VerificationSignature` once you are done with it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate sha2;
 use core::ptr;
 use std::cell::RefCell;
 use std::error::Error;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::{slice, str};
 
@@ -25,14 +25,14 @@ type HmacSha512 = Hmac<Sha512>;
 
 #[cfg(not(feature = "cbindgen"))]
 thread_local! {
-    static LAST_ERROR: RefCell<Option<Box<Error>>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);
 }
 
 /// Update the last error that occured.
 #[cfg(not(feature = "cbindgen"))]
 fn update_last_error<T>(err: T)
 where
-    T: Into<Box<Error>>,
+    T: Into<Box<dyn Error>>,
 {
     LAST_ERROR.with(|prev| {
         *prev.borrow_mut() = Some(err.into());

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -108,7 +108,7 @@ namespace challenge_bypass_ristretto {
 
   TokenPreimage TokenPreimage::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_TokenPreimage> raw_preimage(token_preimage_decode_base64(encoded.c_str()), token_preimage_destroy);
+    std::shared_ptr<C_TokenPreimage> raw_preimage(token_preimage_decode_base64((const uint8_t*) encoded.data(), encoded.length()), token_preimage_destroy);
     if (raw_preimage == nullptr) {
       THROW(TokenException::last_error("Failed to decode token preimage"));
     }
@@ -151,7 +151,7 @@ namespace challenge_bypass_ristretto {
 
   Token Token::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_Token> raw_tok(token_decode_base64(encoded.c_str()), token_destroy);
+    std::shared_ptr<C_Token> raw_tok(token_decode_base64((const uint8_t*) encoded.data(), encoded.length()), token_destroy);
     if (raw_tok == nullptr) {
       THROW(TokenException::last_error("Failed to decode token"));
     }
@@ -183,7 +183,7 @@ namespace challenge_bypass_ristretto {
 
   BlindedToken BlindedToken::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_BlindedToken> raw_blinded(blinded_token_decode_base64(encoded.c_str()), blinded_token_destroy);
+    std::shared_ptr<C_BlindedToken> raw_blinded(blinded_token_decode_base64((const uint8_t*) encoded.data(), encoded.length()), blinded_token_destroy);
     if (raw_blinded == nullptr) {
       THROW(TokenException::last_error("Failed to decode blinded token"));
     }
@@ -215,7 +215,7 @@ namespace challenge_bypass_ristretto {
 
   SignedToken SignedToken::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_SignedToken> raw_signed(signed_token_decode_base64(encoded.c_str()), signed_token_destroy);
+    std::shared_ptr<C_SignedToken> raw_signed(signed_token_decode_base64((const uint8_t*) encoded.data(), encoded.length()), signed_token_destroy);
     if (raw_signed == nullptr) {
       THROW(TokenException::last_error("Failed to decode signed token"));
     }
@@ -247,7 +247,7 @@ namespace challenge_bypass_ristretto {
 
   VerificationSignature VerificationSignature::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_VerificationSignature> raw_sig(verification_signature_decode_base64(encoded.c_str()), verification_signature_destroy);
+    std::shared_ptr<C_VerificationSignature> raw_sig(verification_signature_decode_base64((const uint8_t*) encoded.data(), encoded.length()), verification_signature_destroy);
     if (raw_sig == nullptr) {
       THROW(TokenException::last_error("Failed to decode verification signature"));
     }
@@ -281,7 +281,7 @@ namespace challenge_bypass_ristretto {
 
   UnblindedToken UnblindedToken::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_UnblindedToken> raw_unblinded(unblinded_token_decode_base64(encoded.c_str()), unblinded_token_destroy);
+    std::shared_ptr<C_UnblindedToken> raw_unblinded(unblinded_token_decode_base64((const uint8_t*) encoded.data(), encoded.length()), unblinded_token_destroy);
     if (raw_unblinded == nullptr) {
       THROW(TokenException::last_error("Failed to decode unblinded token"));
     }
@@ -367,7 +367,7 @@ namespace challenge_bypass_ristretto {
 
   SigningKey SigningKey::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_SigningKey> raw_key(signing_key_decode_base64(encoded.c_str()), signing_key_destroy);
+    std::shared_ptr<C_SigningKey> raw_key(signing_key_decode_base64((const uint8_t*) encoded.data(), encoded.length()), signing_key_destroy);
     if (raw_key == nullptr) {
       THROW(TokenException::last_error("Failed to decode signing key"));
     }
@@ -391,7 +391,7 @@ namespace challenge_bypass_ristretto {
 
   PublicKey PublicKey::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_PublicKey> raw_key(public_key_decode_base64(encoded.c_str()), public_key_destroy);
+    std::shared_ptr<C_PublicKey> raw_key(public_key_decode_base64((const uint8_t*) encoded.data(), encoded.length()), public_key_destroy);
     if (raw_key == nullptr) {
       THROW(TokenException::last_error("Failed to decode public key"));
     }
@@ -432,7 +432,7 @@ namespace challenge_bypass_ristretto {
 
   DLEQProof DLEQProof::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_DLEQProof> raw_proof(dleq_proof_decode_base64(encoded.c_str()), dleq_proof_destroy);
+    std::shared_ptr<C_DLEQProof> raw_proof(dleq_proof_decode_base64((const uint8_t*) encoded.data(), encoded.length()), dleq_proof_destroy);
     if (raw_proof == nullptr) {
       THROW(TokenException::last_error("Failed to decode DLEQ proof"));
     }
@@ -539,7 +539,7 @@ namespace challenge_bypass_ristretto {
 
   BatchDLEQProof BatchDLEQProof::decode_base64(const std::string encoded) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_BatchDLEQProof> raw_proof(batch_dleq_proof_decode_base64(encoded.c_str()), batch_dleq_proof_destroy);
+    std::shared_ptr<C_BatchDLEQProof> raw_proof(batch_dleq_proof_decode_base64((const uint8_t*) encoded.data(), encoded.length()), batch_dleq_proof_destroy);
     if (raw_proof == nullptr) {
       THROW(TokenException::last_error("Failed to decode batch DLEQ proof"));
     }

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -313,7 +313,7 @@ namespace challenge_bypass_ristretto {
 
   VerificationSignature VerificationKey::sign(const std::string message) {
     CLEAR_LAST_EXCEPTION();
-    std::shared_ptr<C_VerificationSignature> raw_verification_signature(verification_key_sign_sha512(raw.get(), message.c_str()), verification_signature_destroy);
+    std::shared_ptr<C_VerificationSignature> raw_verification_signature(verification_key_sign_sha512(raw.get(), (const uint8_t*) message.data(), message.length()), verification_signature_destroy);
     if (raw_verification_signature == nullptr) {
       THROW(TokenException::last_error("Failed to sign message"));
     }
@@ -322,7 +322,7 @@ namespace challenge_bypass_ristretto {
 
   bool VerificationKey::verify(VerificationSignature sig, const std::string message) {
     CLEAR_LAST_EXCEPTION();
-    int result = verification_key_invalid_sha512(raw.get(), sig.raw.get(), message.c_str());
+    int result = verification_key_invalid_sha512(raw.get(), sig.raw.get(), (const uint8_t*) message.data(), message.length());
     if (result < 0) {
       THROW(TokenException::last_error("Failed to verify message signature"));
     }


### PR DESCRIPTION
fixes #51 by no longer passing strings to `verification_key_sign_sha512` and `verification_key_invalid_sha512` with C conventions (null terminated) and instead passing an explicit length

crate version has been bumped as C API has changed, however C++ / Golang APIs provided by the bindings are unchanged